### PR TITLE
Update to support IDEA 2021.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # RON Extended Support Changelog
 
 ## [Unreleased]
+### Fixed
+- Updated plugin to support new versions of IDE
+
 ## [0.2.5]
 ### Fixed
 - Fixed incorrect parsing of binary and octal literals (an incorrect literals where considered fine 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,16 @@
 
 pluginGroup = com.github.madwareru.intellijronremix
 pluginName = RON Extended Support
-pluginVersion = 0.2.5
+pluginVersion = 0.2.6
 
 pluginSinceBuild = 203
-pluginUntilBuild = 212.*
+pluginUntilBuild = 213.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.3.2, 2021.1, 2021.2
+pluginVerifierIdeVersions = 2021.2, 2021.3
 
 platformType = IC
-platformVersion = 2021.2
+platformVersion = 2021.3
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
This fix should let users of latest JetBrains IDEs continue using of a plugin. Fix for #19 