### PR TITLE
Update for 2025 Rust Rover

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
@@ -50,7 +50,7 @@ jobs:
 
       # Setup Java 17 environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: corretto
           java-version: 17
@@ -79,14 +79,14 @@ jobs:
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tests-result
           path: ${{ github.workspace }}/build/reports/tests
 
       # Cache Plugin Verifier IDEs
       - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
           key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
@@ -98,7 +98,7 @@ jobs:
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
@@ -115,7 +115,7 @@ jobs:
 
       # Store already-built plugin as an artifact for downloading
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.artifact.outputs.filename }}
           path: ./build/distributions/content/*/*
@@ -133,7 +133,7 @@ jobs:
 
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Remove old release drafts by using the curl request for the available releases with draft flag
       - name: Remove Old Release Drafts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           echo "::set-output name=name::$NAME"
           echo "::set-output name=changelog::$CHANGELOG"
           echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
-          ./gradlew listProductsReleases # prepare list of IDEs for Plugin Verifier
+          ./gradlew printProductsReleases # prepare list of IDEs for Plugin Verifier
       # Run tests
       - name: Run Tests
         run: ./gradlew test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
 
       # Setup Java 17 environment for the next steps
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: corretto
           java-version: 17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.8.20"
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.15.0"
+    id("org.jetbrains.intellij.platform") version "2.6.0"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "2.0.0"
+    id("org.jetbrains.changelog") version "2.2.1"
     // see https://plugins.jetbrains.com/docs/intellij/tools-gradle-grammar-kit-plugin.html
     id("org.jetbrains.grammarkit") version "2022.3.2.1"
 }
@@ -18,11 +18,23 @@ plugins {
 group = properties("pluginGroup")
 version = properties("pluginVersion")
 
+dependencies {
+    intellijPlatform {
+        rustRover("2025.1.2")
+        bundledPlugin("com.jetbrains.rust")
+    }
+}
+
 // Configure project's dependencies
 repositories {
     mavenCentral()
-}
 
+    intellijPlatform {
+        defaultRepositories()
+
+
+    }
+}
 // Set the JVM language level used to build project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.
 kotlin {
     jvmToolchain (17)
@@ -32,14 +44,14 @@ sourceSets["main"].java.srcDirs("src/main/gen")
 
 // Configure gradle-intellij-plugin plugin.
 // Read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    pluginName.set(properties("pluginName"))
-    version.set(properties("platformVersion"))
-    type.set(properties("platformType"))
-
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
-}
+//intellij {
+//    pluginName.set(properties("pluginName"))
+//    version.set(properties("platformVersion"))
+//    type.set(properties("platformType"))
+//
+//    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
+//    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+//}
 
 changelog {
     version.set(properties("pluginVersion"))
@@ -56,20 +68,21 @@ configure<JavaPluginExtension> {
 }
 
 tasks {
-    test {
-        useJUnitPlatform()
-    }
+//    test {
+//        useJUnitPlatform()
+//    }
 
     compileKotlin {
-        kotlinOptions.jvmTarget = "17"
+
     }
 
     wrapper {
         gradleVersion = properties("gradleVersion")
     }
 
+
     patchPluginXml {
-        version.set(properties("pluginVersion"))
+//        version.set(properties("pluginVersion"))
         sinceBuild.set(properties("pluginSinceBuild"))
         untilBuild.set(properties("pluginUntilBuild"))
 
@@ -104,12 +117,12 @@ tasks {
 
     // Configure UI tests plugin
     // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
-    }
+//    runIdeForUiTests {
+//        systemProperty("robot-server.port", "8082")
+//        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
+//        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
+//        systemProperty("jb.consents.confirmation.enabled", "false")
+//    }
 
     signPlugin {
         certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
@@ -123,6 +136,6 @@ tasks {
         // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
+        // channels.add(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first())
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@
 
 pluginGroup = com.github.madwareru.intellijronremix
 pluginName = RON Extended Support
-pluginVersion = 0.3.2
+pluginVersion = 0.4.0
 
-pluginSinceBuild = 233.0
-pluginUntilBuild = 233.*
+pluginSinceBuild = 252.0
+pluginUntilBuild = 252.*
 
 platformType = IC
-platformVersion = 2023.3
+platformVersion = 2025.2
 
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = org.rust.lang:233.15445,org.toml.lang
+platformPlugins = org.toml.lang
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,4 @@
 rootProject.name = "RON Extended Support"
+
+include(":submodule")
+

--- a/src/main/kotlin/com/github/madwareru/intellijronremix/rust/RonToRustTypeReference.kt
+++ b/src/main/kotlin/com/github/madwareru/intellijronremix/rust/RonToRustTypeReference.kt
@@ -45,12 +45,12 @@ class RonToRustTypeReference(ronObjectName: RONObjectName) : RonToRustReferenceC
                         when {
                             element.text.removeSuffix(CompletionUtilCore.DUMMY_IDENTIFIER_TRIMMED).isEmpty() -> {
                                 val scope = GlobalSearchScope.projectScope(project)
-                                StubIndex.getInstance().getAllKeys(RsNamedElementIndex.KEY, project)
+                                StubIndex.getInstance().getAllKeys(RsNamedElementIndex.Helper.KEY, project)
                                     .asSequence()
                                     // avoid most generics early
                                     .filter { it.length >= 2 }
                                     .flatMap {
-                                        RsNamedElementIndex.findElementsByName(project, it, scope)
+                                        RsNamedElementIndex.Helper.findElementsByName(project, it, scope)
                                             .filterIsInstance<RsFieldsOwner>()
                                             .filter(RsFieldsOwner::isVisibleToRON)
                                     }
@@ -58,7 +58,7 @@ class RonToRustTypeReference(ronObjectName: RONObjectName) : RonToRustReferenceC
                             else -> {
                                 val scope = GlobalSearchScope.allScope(project)
                                 val start = element.text[0]
-                                StubIndex.getInstance().getAllKeys(RsNamedElementIndex.KEY, project)
+                                StubIndex.getInstance().getAllKeys(RsNamedElementIndex.Helper.KEY, project)
                                     .asSequence()
                                     // avoid most generics early
                                     .filter { it.length >= 2 }
@@ -66,7 +66,7 @@ class RonToRustTypeReference(ronObjectName: RONObjectName) : RonToRustReferenceC
                                     // but we have to require at least the first letter, for performance reasons
                                     .filter { it.startsWith(start) }
                                     .flatMap {
-                                        val elementsByName = RsNamedElementIndex.findElementsByName(project, it, scope)
+                                        val elementsByName = RsNamedElementIndex.Helper.findElementsByName(project, it, scope)
                                         elementsByName
                                             .filterIsInstance<RsFieldsOwner>()
                                             .filter(RsFieldsOwner::isVisibleToRON)


### PR DESCRIPTION
This bumps some dependency versions and (hopefully) makes it work for the newer IDEs

Tested against my own local version of RustRover (2025.2)

Still TODO:
- [ ] Fix CI: Some of it is busted on my fork, [here](https://github.com/tom-frantz/intellij-ron-remix/actions/runs/15920015660/job/44904641969?pr=2)
- [ ] Fix the comments I made in the Gradle job changes.
